### PR TITLE
Improve Outlook search performance and body cleaning flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ An MCP (Model Context Protocol) server for interacting with Microsoft Outlook th
 - Automatic noise and disclaimer removal
 - Character and format normalization
 - Boilerplate detection and truncation
+- Optional lightweight mode to skip deep HTML cleaning (`clean_body=False`)
 
 ### 📊 Structured Formatting
 - Consistent dictionary format output
@@ -62,6 +63,8 @@ Create a `.env` file in the project root:
 CLIENT_ID=your_azure_client_id
 CLIENT_SECRET=your_azure_client_secret
 TENANT_ID=your_azure_tenant_id
+# Optional: comma separated folders to search by default
+OUTLOOK_DEFAULT_FOLDERS=Inbox,SentItems,Drafts
 ```
 
 **Note:** Make sure to use exactly these variable names (`CLIENT_ID`, `CLIENT_SECRET`, `TENANT_ID`) as they are required by the server.

--- a/src/mcp_outlook_server/clean_utils.py
+++ b/src/mcp_outlook_server/clean_utils.py
@@ -1,7 +1,9 @@
 import re, logging, html, html2text, unicodedata
 from bs4 import BeautifulSoup
 from functools import wraps
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Tuple
+from inscriptis import get_text
+
 from .format_utils import get_date, get_sender_info, get_message_attribute
 
 logger = logging.getLogger(__name__)
@@ -41,21 +43,30 @@ def clean_text(text, aggressive=False):
     text = '\n'.join(clean_lines)
     return unicodedata.normalize('NFC', text)
 
-@exception_handler()
-def html_to_text(html_content):
-    # Convert HTML to plain text.
-    if not html_content: 
-        return ""
-    
-    try: html_content = html.unescape(html_content) # Decode HTML entities.
-    except Exception as e: logger.debug(f"Error unescaping HTML: {e}")
+def _remove_unwanted_tags(soup: BeautifulSoup) -> None:
+    """Strip script, style and other noisy elements from the soup."""
 
-    soup = BeautifulSoup(html_content, 'html.parser')
-    
-    for tag_name in ['script', 'style', 'nav', 'footer', 'header', 'aside', 'noscript', 'form', 'input', 'button', 'meta', 'link']:
+    for tag_name in [
+        "script",
+        "style",
+        "nav",
+        "footer",
+        "header",
+        "aside",
+        "noscript",
+        "form",
+        "input",
+        "button",
+        "meta",
+        "link",
+    ]:
         for tag in soup.find_all(tag_name):
-            tag.decompose() # Remove unwanted elements.
-    
+            tag.decompose()
+
+
+def _build_html2text() -> html2text.HTML2Text:
+    """Configure a html2text parser instance."""
+
     h = html2text.HTML2Text()
     h.ignore_links = True
     h.ignore_images = True
@@ -63,62 +74,111 @@ def html_to_text(html_content):
     h.ignore_emphasis = True
     h.body_width = 0
     h.unicode_snob = True
-    h.ul_item_mark = ' ' 
-    h.emphasis_mark = ''
+    h.ul_item_mark = " "
+    h.emphasis_mark = ""
     h.single_line_break = True
+    return h
 
+
+def _post_process_markdown(text: str) -> str:
+    """Clean remnants produced by html2text conversion."""
+
+    text = re.sub(r"<[^>]+>", "", text)
+    text = re.sub(
+        r"\!\[.*?\]\(.*?\)|\[.*?\]\(.*?\)|\\[cid:[^\]]*\\]|\\[[^\]]*\\]",
+        "",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(r"\|[\s\-\|]*\||^\s*\||\|\s*$|\s*\|\s*", " ", text, flags=re.MULTILINE)
+    text = re.sub(r"[\*\_]{2,}|[\#\=\-\+]{2,}", "", text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n\s*\n", "\n\n", text)
+    text = re.sub(r"^\s+|\s+$", "", text, flags=re.MULTILINE)
+    lines = text.split("\n")
+    clean_lines = [line for line in lines if line.strip() and re.search(r"[a-zA-Z0-9]", line)]
+    return "\n".join(clean_lines)
+
+
+@exception_handler()
+def html_to_text(html_content, deep_clean: bool = True):
+    """Convert HTML to plain text.
+
+    When ``deep_clean`` is ``False`` only structural tags are removed, providing a
+    faster but less thorough conversion.
+    """
+
+    if not html_content:
+        return ""
+
+    try:
+        html_content = html.unescape(html_content)
+    except Exception as e:  # pragma: no cover - defensive logging
+        logger.debug(f"Error unescaping HTML: {e}")
+
+    soup = BeautifulSoup(html_content, "html.parser")
+    if deep_clean:
+        _remove_unwanted_tags(soup)
+
+    h = _build_html2text()
     text = h.handle(str(soup))
-    
-    text = re.sub(r'<[^>]+>', '', text) # Remove any remaining HTML tags.
-    text = re.sub(r'\!\[.*?\]\(.*?\)|\[.*?\]\(.*?\)|\\[cid:[^\]]*\\]|\\[[^\]]*\\]', '', text, flags=re.IGNORECASE) # Remove markdown images/links, cids, brackets.
-    text = re.sub(r'\|[\s\-\|]*\||^\s*\||\|\s*$|\s*\|\s*', ' ', text, flags=re.MULTILINE) # Clean table remnants.
-    text = re.sub(r'[\*\_]{2,}|[\#\=\-\+]{2,}', '', text) # Remove excessive formatting chars.
-    text = re.sub(r'[ \t]+', ' ', text) # Normalize spaces/tabs.
-    text = re.sub(r'\n\s*\n', '\n\n', text) # Ensure max one blank line.
-    text = re.sub(r'^\s+|\s+$', '', text, flags=re.MULTILINE) # Trim leading/trailing whitespace from each line.
-    
-    # Remove empty lines or lines with only residual non-alphanumeric characters.
-    lines = text.split('\n')
-    clean_lines = [line for line in lines if line.strip() and re.search(r'[a-zA-Z0-9]', line)]
-    text = '\n'.join(clean_lines)
-    
-    return text.strip()
+    return _post_process_markdown(text) if deep_clean else text.strip()
+
+def _strip_urls(text: str) -> str:
+    patterns = [
+        r"https?://[^\s\n<>()\[\]]+",
+        r"ftp://[^\s\n<>()\[\]]+",
+        r"www\.[^\s\n<>()\[\]]+",
+        r"mailto:[^\s\n<>()\[\]]+",
+        r"tel:[+\d\s\(\)\-]+",
+    ]
+    for pattern in patterns:
+        text = re.sub(pattern, "", text, flags=re.IGNORECASE)
+    return text
+
+
+def _normalize_symbols(text: str) -> str:
+    text = re.sub(r"[•·▪▫◦‣⁃]", "-", text)
+    text = re.sub(r"[\"\'`‘’“”«»]", '"', text)
+    text = re.sub(r"[–—―]", "-", text)
+    text = re.sub(r"…", "...", text)
+    return re.sub(r"©|®|™", "", text)
+
+
+def _deduplicate_lines(lines: List[str]) -> List[str]:
+    unique_lines: List[str] = []
+    prev_line_hash = None
+    for line in lines:
+        stripped_line = line.strip()
+        current_hash = hash(stripped_line)
+        if (
+            stripped_line
+            and re.search(r"[a-zA-Z0-9]", stripped_line)
+            and current_hash != prev_line_hash
+            and len(stripped_line) > 1
+        ):
+            unique_lines.append(stripped_line)
+            prev_line_hash = current_hash
+    return unique_lines
+
 
 @exception_handler()
 def process_text(text):
-    # Process text for cleaner output.
-    if not text: 
+    """Process text to remove noise and normalise characters."""
+
+    if not text:
         return ""
-    
-    url_pattern_list = [ # More comprehensive TLD list.
-        r'https?://[^\s\n<>()\[\]]+', r'ftp://[^\s\n<>()\[\]]+', r'www\.[^\s\n<>()\[\]]+',
-        r'mailto:[^\s\n<>()\[\]]+', r'tel:[+\d\s\(\)\-]+'
-    ]
-    for pattern in url_pattern_list: 
-        text = re.sub(pattern, '', text, flags=re.IGNORECASE) # Remove URLs and links.
 
-    text = re.sub(r'[•·▪▫◦‣⁃]', '-', text) # Normalize bullet points.
-    text = re.sub(r'[\"\'`‘’“”«»]', '"', text) # Normalize quotes.
-    text = re.sub(r'[–—―]', '-', text) # Normalize dashes.
-    text = re.sub(r'…', '...', text) # Normalize ellipsis.
-    text = re.sub(r'©|®|™', '', text) # Remove copyright/trademark symbols.
-
-    lines = text.split('\n')
-    unique_lines, prev_line_hash = [], None
-    for line in lines: # Remove duplicate consecutive lines and very short/artifact lines.
-        stripped_line = line.strip()
-        current_hash = hash(stripped_line)
-        if stripped_line and re.search(r'[a-zA-Z0-9]', stripped_line) and current_hash != prev_line_hash and len(stripped_line) > 1:
-            unique_lines.append(stripped_line)
-            prev_line_hash = current_hash
-    result = '\n'.join(unique_lines)
-    
-    # Eliminar saltos de línea y espacios excesivos
-    result = re.sub(r'\n{3,}', '\n\n', result)
-    result = re.sub(r'[ \t]{2,}', ' ', result).strip()
-    lines = result.split('\n')
-    result = '\n'.join([line for line in lines if line.strip() and re.search(r'[a-zA-Z0-9]', line)])
-    # Corte agresivo de boilerplate/disclaimers
+    text = _strip_urls(text)
+    text = _normalize_symbols(text)
+    unique_lines = _deduplicate_lines(text.split("\n"))
+    result = "\n".join(unique_lines)
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    result = re.sub(r"[ \t]{2,}", " ", result).strip()
+    lines = result.split("\n")
+    result = "\n".join(
+        [line for line in lines if line.strip() and re.search(r"[a-zA-Z0-9]", line)]
+    )
     result = remove_email_noise(result)
     return result.strip()
 
@@ -138,99 +198,192 @@ def remove_email_noise(text: str) -> str:
             return text[:match.start()].strip()
     return text
 
-def clean_email_content(html_content, aggressive=True):
-    # Clean email content (HTML or plain).
-    if not html_content: return ""
+def clean_email_content(html_content, aggressive: bool = True, deep_clean: bool = True):
+    """Clean email content (HTML or plain).
+
+    Parameters
+    ----------
+    html_content: str
+        Raw HTML or plain text from the email body.
+    aggressive: bool
+        Whether to apply aggressive character stripping.
+    deep_clean: bool
+        If ``False`` a lightweight HTML to text conversion is used.
+    """
+
+    if not html_content:
+        return ""
     try:
-        text_from_html = html_to_text(html_content)
+        if deep_clean:
+            text_from_html = html_to_text(html_content, deep_clean=True)
+        else:
+            text_from_html = get_text(html_content)
         cleaned_text = clean_text(text_from_html, aggressive=aggressive)
         processed_text = process_text(cleaned_text)
-        return re.sub(r'\n{3,}', '\n\n', processed_text).strip()
+        return re.sub(r"\n{3,}", "\n\n", processed_text).strip()
     except Exception as e:
         logger.error(f"Error in email cleaning pipeline: {e}. Falling back.")
-        try: # Fallback strategy.
-            fallback_text = html_to_text(html_content) 
-            if fallback_text: fallback_text = process_text(fallback_text)
+        try:  # Fallback strategy.
+            fallback_text = html_to_text(html_content, deep_clean=False)
+            if fallback_text:
+                fallback_text = process_text(fallback_text)
             text_content = fallback_text or html_content
-            text_content = re.sub(r'<[^>]+>', ' ', text_content)
-            return re.sub(r'\s+', ' ', text_content).strip()
-        except Exception as fallback_e: # Absolute last resort.
+            text_content = re.sub(r"<[^>]+>", " ", text_content)
+            return re.sub(r"\s+", " ", text_content).strip()
+        except Exception as fallback_e:  # Absolute last resort.
             logger.error(f"Error in fallback email cleaning: {fallback_e}")
-            text = re.sub(r'<[^>]+>', ' ', html_content)
-            return re.sub(r'\s+', ' ', text).strip()
+            text = re.sub(r"<[^>]+>", " ", html_content)
+            return re.sub(r"\s+", " ", text).strip()
 
-def format_email_structured(message: Any) -> Dict[str, Any]:
-    # Format email into a structured dictionary.
-    if not message:
-        return {"remitente": "Desconocido", "fecha": "Desconocida", "copiados": [], "asunto": "Sin asunto", "resumen": "No disponible", "cuerpo": "Contenido no disponible", "id": "Desconocido"}
-    sender_name, sender_email = get_sender_info(message)
-    fecha_raw = get_date(message)
-    fecha = "Desconocida" if fecha_raw == "Unknown" else fecha_raw
-    remitente = f"{sender_name} <{sender_email}>" if sender_name else (sender_email or "Desconocido")
-    copiados = []
+def _extract_recipients(message: Any) -> List[str]:
+    """Return a list of CC/BCC recipients."""
+
+    recipients_list: List[str] = []
     try:
-        for cc_type in ['ccRecipients', 'bccRecipients']:
+        for cc_type in ["ccRecipients", "bccRecipients"]:
             recipients = get_message_attribute(message, [cc_type])
             if recipients:
                 for recipient in recipients:
-                    if hasattr(recipient, 'emailAddress'):
+                    if hasattr(recipient, "emailAddress"):
                         email_addr = recipient.emailAddress
-                        name = get_message_attribute(email_addr, ['name'], "")
-                        email = get_message_attribute(email_addr, ['address'], "")
-                        if email: copiados.append(f"{name} <{email}>" if name else email)
-    except Exception: pass
-    asunto = get_message_attribute(message, ['subject'], "Sin asunto")
+                        name = get_message_attribute(email_addr, ["name"], "")
+                        email = get_message_attribute(email_addr, ["address"], "")
+                        if email:
+                            recipients_list.append(f"{name} <{email}>" if name else email)
+    except Exception:
+        pass
+    return recipients_list
+
+
+def _extract_body_and_summary(message: Any, clean_body: bool) -> Tuple[str, str]:
+    """Retrieve and clean the body content and build a summary."""
+
     cuerpo_raw, content_type = "", "text"
     try:
-        if hasattr(message, 'body') and message.body:
+        if hasattr(message, "body") and message.body:
             body = message.body
-            # Compatibilidad: puede ser dict o tener atributos
             if isinstance(body, dict):
-                cuerpo_raw = body.get('content', "")
-                content_type = body.get('contentType', body.get('content_type', 'text')).lower()
+                cuerpo_raw = body.get("content", "")
+                content_type = body.get("contentType", body.get("content_type", "text")).lower()
             else:
-                cuerpo_raw = getattr(body, 'content', "")
-                content_type = getattr(body, 'contentType', getattr(body, 'content_type', 'text')).lower()
-    except Exception: pass
-    cuerpo = clean_email_content(cuerpo_raw, aggressive=True) if content_type == 'html' else process_text(clean_text(cuerpo_raw or "", aggressive=True))
-    if not cuerpo.strip(): cuerpo = "Contenido no disponible"
-    if cuerpo == "Contenido no disponible": resumen = "No disponible"
-    else:
-        resumen_text = re.sub(r'\s+', ' ', cuerpo.replace('\n', ' ')).strip()
-        resumen = (resumen_text[:150] + "..." if len(resumen_text) > 150 else resumen_text)
-        if not resumen.strip(): resumen = "Contenido procesado, resumen no extraíble."
-    message_id = get_message_attribute(message, ['id'], "Desconocido")
-    return {"remitente": remitente, "fecha": fecha, "copiados": copiados, "asunto": asunto, "resumen": resumen, "cuerpo": cuerpo, "id": message_id}
+                cuerpo_raw = getattr(body, "content", "")
+                content_type = getattr(
+                    body, "contentType", getattr(body, "content_type", "text")
+                ).lower()
+    except Exception:
+        pass
 
-def format_emails_list_structured(messages: List[Any]) -> List[Dict[str, Any]]:
-    # Format a list of emails into structured dictionaries.
-    return [format_email_structured(msg) for msg in messages] if messages else []
+    if content_type == "html":
+        cuerpo = clean_email_content(
+            cuerpo_raw, aggressive=True, deep_clean=clean_body
+        )
+    else:
+        cuerpo = process_text(clean_text(cuerpo_raw or "", aggressive=True))
+
+    if not cuerpo.strip():
+        cuerpo = "Contenido no disponible"
+    if cuerpo == "Contenido no disponible":
+        resumen = "No disponible"
+    else:
+        resumen_text = re.sub(r"\s+", " ", cuerpo.replace("\n", " ")).strip()
+        resumen = (
+            resumen_text[:150] + "..." if len(resumen_text) > 150 else resumen_text
+        )
+        if not resumen.strip():
+            resumen = "Contenido procesado, resumen no extraíble."
+    return cuerpo, resumen
+
+
+def format_email_structured(message: Any, clean_body: bool = True) -> Dict[str, Any]:
+    """Format an email object into a structured dictionary."""
+
+    if not message:
+        return {
+            "remitente": "Desconocido",
+            "fecha": "Desconocida",
+            "copiados": [],
+            "asunto": "Sin asunto",
+            "resumen": "No disponible",
+            "cuerpo": "Contenido no disponible",
+            "id": "Desconocido",
+        }
+
+    sender_name, sender_email = get_sender_info(message)
+    fecha_raw = get_date(message)
+    fecha = "Desconocida" if fecha_raw == "Unknown" else fecha_raw
+    remitente = (
+        f"{sender_name} <{sender_email}>" if sender_name else (sender_email or "Desconocido")
+    )
+    copiados = _extract_recipients(message)
+    asunto = get_message_attribute(message, ["subject"], "Sin asunto")
+    cuerpo, resumen = _extract_body_and_summary(message, clean_body)
+    message_id = get_message_attribute(message, ["id"], "Desconocido")
+    return {
+        "remitente": remitente,
+        "fecha": fecha,
+        "copiados": copiados,
+        "asunto": asunto,
+        "resumen": resumen,
+        "cuerpo": cuerpo,
+        "id": message_id,
+    }
+
+def format_emails_list_structured(
+    messages: List[Any], clean_body: bool = True
+) -> List[Dict[str, Any]]:
+    """Format a list of emails into structured dictionaries."""
+
+    return [format_email_structured(msg, clean_body=clean_body) for msg in messages] if messages else []
 
 def format_email_structured_no_body(message: Any) -> Dict[str, Any]:
-    # Fromat email into a structured dictionary without body content.
+    """Format email into a structured dictionary without body content."""
+
     if not message:
-        return {"remitente": "Desconocido", "fecha": "Desconocida", "copiados": [], "asunto": "Sin asunto", "resumen": "No disponible", "cuerpo": "Contenido no disponible", "id": "Desconocido"}
+        return {
+            "remitente": "Desconocido",
+            "fecha": "Desconocida",
+            "copiados": [],
+            "asunto": "Sin asunto",
+            "resumen": "No disponible",
+            "cuerpo": "Contenido no disponible",
+            "id": "Desconocido",
+        }
     sender_name, sender_email = get_sender_info(message)
     fecha_raw = get_date(message)
     fecha = "Desconocida" if fecha_raw == "Unknown" else fecha_raw
     remitente = f"{sender_name} <{sender_email}>" if sender_name else (sender_email or "Desconocido")
     copiados = []
     try:
-        for cc_type in ['ccRecipients', 'bccRecipients']:
+        for cc_type in ["ccRecipients", "bccRecipients"]:
             recipients = get_message_attribute(message, [cc_type])
             if recipients:
                 for recipient in recipients:
-                    if hasattr(recipient, 'emailAddress'):
+                    if hasattr(recipient, "emailAddress"):
                         email_addr = recipient.emailAddress
-                        name = get_message_attribute(email_addr, ['name'], "")
-                        email = get_message_attribute(email_addr, ['address'], "")
-                        if email: copiados.append(f"{name} <{email}>" if name else email)
-    except Exception: pass
-    asunto = get_message_attribute(message, ['subject'], "Sin asunto")
-    resumen = get_message_attribute(message, ['bodyPreview'], "No disponible")
+                        name = get_message_attribute(email_addr, ["name"], "")
+                        email = get_message_attribute(email_addr, ["address"], "")
+                        if email:
+                            copiados.append(f"{name} <{email}>" if name else email)
+    except Exception:
+        pass
+    asunto = get_message_attribute(message, ["subject"], "Sin asunto")
+    resumen = get_message_attribute(message, ["bodyPreview"], "No disponible")
     cuerpo = "Contenido no disponible"
-    message_id = get_message_attribute(message, ['id'], "Desconocido")
-    return {"remitente": remitente, "fecha": fecha, "copiados": copiados, "asunto": asunto, "resumen": resumen, "cuerpo": cuerpo, "id": message_id}
+    message_id = get_message_attribute(message, ["id"], "Desconocido")
+    return {
+        "remitente": remitente,
+        "fecha": fecha,
+        "copiados": copiados,
+        "asunto": asunto,
+        "resumen": resumen,
+        "cuerpo": cuerpo,
+        "id": message_id,
+    }
 
-def format_emails_list_structured_no_body(messages: List[Any]) -> List[Dict[str, Any]]:
+
+def format_emails_list_structured_no_body(
+    messages: List[Any], **_
+) -> List[Dict[str, Any]]:
+    """Format a list of emails into structured dictionaries without body."""
+
     return [format_email_structured_no_body(msg) for msg in messages] if messages else []

--- a/src/mcp_outlook_server/format_utils_search.py
+++ b/src/mcp_outlook_server/format_utils_search.py
@@ -5,12 +5,19 @@ Formateo para resultados de búsqueda $search (KQL) de Microsoft Graph API (JSON
 from typing import Any, Dict, List
 from .clean_utils import clean_email_content, clean_text, process_text
 
-def format_email_output_search(msg: Dict[str, Any], as_text: bool = True) -> Dict[str, Any]:
-    # Formatea un mensaje JSON plano de Graph API para salida homogénea
+def format_email_output_search(
+    msg: Dict[str, Any], as_text: bool = True, clean_body: bool = True
+) -> Dict[str, Any]:
+    """Format plain JSON Graph API message for uniform output."""
+
     body_raw = msg.get("body", {}).get("content") if msg.get("body") else None
-    content_type = msg.get("body", {}).get("contentType", "text").lower() if msg.get("body") else "text"
+    content_type = (
+        msg.get("body", {}).get("contentType", "text").lower()
+        if msg.get("body")
+        else "text"
+    )
     if body_raw and content_type == "html":
-        body_clean = clean_email_content(body_raw, aggressive=True)
+        body_clean = clean_email_content(body_raw, aggressive=True, deep_clean=clean_body)
     elif body_raw:
         body_clean = process_text(clean_text(body_raw, aggressive=True))
     else:
@@ -28,7 +35,7 @@ def format_email_output_search(msg: Dict[str, Any], as_text: bool = True) -> Dic
         "importance": msg.get("importance"),
         "categories": msg.get("categories", []),
         "bodyPreview": msg.get("bodyPreview"),
-        "body": body_clean
+        "body": body_clean,
     }
 
 def format_email_output_search_no_body(msg: Dict[str, Any], as_text: bool = True) -> Dict[str, Any]:
@@ -59,8 +66,13 @@ def _format_address(addr: Any) -> str:
         return addr.get("address", "")
     return str(addr)
 
-def format_emails_list_structured_search(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    return [format_email_output_search(msg) for msg in messages]
+def format_emails_list_structured_search(
+    messages: List[Dict[str, Any]], clean_body: bool = True
+) -> List[Dict[str, Any]]:
+    return [format_email_output_search(msg, clean_body=clean_body) for msg in messages]
 
-def format_emails_list_structured_search_no_body(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def format_emails_list_structured_search_no_body(
+    messages: List[Dict[str, Any]], **_
+) -> List[Dict[str, Any]]:
     return [format_email_output_search_no_body(msg) for msg in messages]
+

--- a/src/mcp_outlook_server/resources.py
+++ b/src/mcp_outlook_server/resources.py
@@ -1,68 +1,159 @@
+"""Utility functions for interacting with Outlook messages via Microsoft Graph."""
+
 from typing import List, Any, Optional, Callable
-from .common import graph_client, _get_graph_access_token
-from .format_utils import format_email_output
-from .clean_utils import format_email_structured, format_emails_list_structured, format_emails_list_structured_no_body
-from .format_utils_search import format_emails_list_structured_search, format_emails_list_structured_search_no_body
+import os
+
 import requests
 
-DEFAULT_FOLDERS = ["Inbox", "SentItems", "Drafts"]
-SELECT_FIELDS_NO_BODY = ["id", "subject", "sender", "from", "toRecipients", "ccRecipients", "bccRecipients", 
-                        "receivedDateTime", "sentDateTime", "isRead", "importance", "categories", "bodyPreview"]
+from .common import graph_client, _get_graph_access_token
+from .format_utils import format_email_output
+from .clean_utils import (
+    format_email_structured,
+    format_emails_list_structured,
+    format_emails_list_structured_no_body,
+)
+from .format_utils_search import (
+    format_emails_list_structured_search,
+    format_emails_list_structured_search_no_body,
+)
+
+# Comma-separated list of folders to search when none are specified
+DEFAULT_FOLDERS = [
+    f.strip() for f in os.getenv("OUTLOOK_DEFAULT_FOLDERS", "Inbox,SentItems,Drafts").split(",") if f.strip()
+]
+SELECT_FIELDS_NO_BODY = [
+    "id",
+    "subject",
+    "sender",
+    "from",
+    "toRecipients",
+    "ccRecipients",
+    "bccRecipients",
+    "receivedDateTime",
+    "sentDateTime",
+    "isRead",
+    "importance",
+    "categories",
+    "bodyPreview",
+]
 
 def _paginate_messages(initial_collection, top: int, max_pages: int = 20) -> List[Any]:
-    """Unified pagination logic for message collections"""
-    messages, page_count = list(initial_collection), 1
-    while initial_collection.has_next and len(messages) < top and page_count <= max_pages:
+    """Iterate through paged results without materialising the entire collection."""
+
+    messages: List[Any] = []
+    page_count = 0
+
+    while page_count <= max_pages:
+        for msg in initial_collection:
+            messages.append(msg)
+            if len(messages) >= top:
+                return messages[:top]
+
+        if not getattr(initial_collection, "has_next", False):
+            break
+
         try:
             initial_collection = initial_collection.get().execute_query()
-            new_messages = list(initial_collection)
-            if not new_messages: break
-            messages.extend(new_messages[:top - len(messages)])
-            page_count += 1
-        except Exception: break
+        except Exception:
+            break
+        page_count += 1
+
     return messages[:top]
 
-def _fetch_from_folders(user_email: str, folders: List[str], top: int, fetch_func: Callable) -> List[Any]:
-    """Unified folder iteration with early termination"""
-    all_messages = []
+def _fetch_from_folders(
+    user_email: str, folders: List[str], top: int, fetch_func: Callable
+) -> List[Any]:
+    """Iterate folders and stop early once the requested number of messages is gathered."""
+
+    all_messages: List[Any] = []
     for folder_name in folders:
-        if len(all_messages) >= top: break
+        if len(all_messages) >= top:
+            break
         try:
             messages = fetch_func(user_email, folder_name, top - len(all_messages))
             all_messages.extend(messages)
-        except Exception: continue
+        except Exception:
+            continue
     return all_messages[:top]
 
-def _fetch_emails(user_email: str, query_filter: Optional[str], folders: Optional[List[str]], top: int, select_fields: Optional[List[str]] = None) -> List[Any]:
+def _fetch_emails(
+    user_email: str,
+    query_filter: Optional[str],
+    folders: Optional[List[str]],
+    top: int,
+    select_fields: Optional[List[str]] = None,
+) -> List[Any]:
+    """Retrieve messages using OData filters."""
+
     def fetch_from_folder(user_email: str, folder_name: str, remaining: int) -> List[Any]:
         query_obj = graph_client.users[user_email].mail_folders[folder_name].messages
-        if select_fields: query_obj = query_obj.select(select_fields)
-        if query_filter: query_obj = query_obj.filter(query_filter)
-        collection = query_obj.paged().top(min(1000, remaining)).get().execute_query()
+        if select_fields:
+            query_obj = query_obj.select(select_fields)
+        if query_filter:
+            query_obj = query_obj.filter(query_filter)
+        collection = (
+            query_obj.paged().top(min(1000, remaining)).get().execute_query()
+        )
         return _paginate_messages(collection, remaining)
-    
-    return _fetch_from_folders(user_email, folders or DEFAULT_FOLDERS, top, fetch_from_folder)
 
-def _fetch_emails_by_search(user_email: str, search_query: str, folders: Optional[List[str]], top: int, select_fields: Optional[List[str]] = None) -> List[Any]:
+    return _fetch_from_folders(
+        user_email, folders or DEFAULT_FOLDERS, top, fetch_from_folder
+    )
+
+def _fetch_emails_by_search(
+    user_email: str,
+    search_query: str,
+    folders: Optional[List[str]],
+    top: int,
+    select_fields: Optional[List[str]] = None,
+) -> List[Any]:
+    """Retrieve messages using Graph $search (KQL) queries."""
+
+    access_token = _get_graph_access_token()
+
     def fetch_from_folder(user_email: str, folder_name: str, remaining: int) -> List[Any]:
-        headers = {"Authorization": f"Bearer {_get_graph_access_token()}", "Content-Type": "application/json"}
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        }
         params = {"$search": f'"{search_query}"', "$top": str(min(1000, remaining))}
-        if select_fields: params["$select"] = ",".join(select_fields)
-        
-        resp = requests.get(f"https://graph.microsoft.com/v1.0/users/{user_email}/mailFolders/{folder_name}/messages", 
-                           headers=headers, params=params)
+        if select_fields:
+            params["$select"] = ",".join(select_fields)
+
+        resp = requests.get(
+            f"https://graph.microsoft.com/v1.0/users/{user_email}/mailFolders/{folder_name}/messages",
+            headers=headers,
+            params=params,
+        )
         resp.raise_for_status()
         return resp.json().get("value", [])[:remaining]
-    
-    return _fetch_from_folders(user_email, folders or DEFAULT_FOLDERS, top, fetch_from_folder)
 
-def _format_results(messages: List[Any], structured: bool, as_text: bool, formatter_structured, formatter_unstructured=None, fields: Optional[List[str]] = None) -> List[Any]:
-    """Unified result formatting logic with optional field filtering"""
-    if structured: 
-        result = formatter_structured(messages)
+    return _fetch_from_folders(
+        user_email, folders or DEFAULT_FOLDERS, top, fetch_from_folder
+    )
+
+def _format_results(
+    messages: List[Any],
+    structured: bool,
+    as_text: bool,
+    formatter_structured,
+    formatter_unstructured=None,
+    fields: Optional[List[str]] = None,
+    clean_body: bool = True,
+) -> List[Any]:
+    """Format results and optionally limit returned fields."""
+
+    if structured:
+        result = formatter_structured(messages, clean_body=clean_body)
         return _filter_fields(result, fields) if fields else result
-    if formatter_unstructured: return formatter_unstructured(messages)
-    return [format_email_output(msg, as_text=as_text) for msg in messages]
+    if formatter_unstructured:
+        return formatter_unstructured(messages)
+    return [
+        format_email_output(
+            msg, as_text=as_text, skip_cleaning=not clean_body, deep_clean=clean_body
+        )
+        for msg in messages
+    ]
 
 def _filter_fields(data: List[dict], fields: List[str]) -> List[dict]:
     """Filter dictionary keys to only include specified fields"""
@@ -87,21 +178,61 @@ def _filter_fields(data: List[dict], fields: List[str]) -> List[dict]:
     
     return [{k: v for k, v in email.items() if k in actual_fields} for email in data]
 
-def search_emails(user_email: str, query_filter: Optional[str] = None, folders: Optional[List[str]] = None, 
-                 top: int = 10, as_text: bool = True, structured: bool = True, include_body: bool = True, fields: Optional[List[str]] = None) -> List[Any]:
-    """Unified email search with OData filters"""
+def search_emails(
+    user_email: str,
+    query_filter: Optional[str] = None,
+    folders: Optional[List[str]] = None,
+    top: int = 10,
+    as_text: bool = True,
+    structured: bool = True,
+    include_body: bool = True,
+    clean_body: bool = True,
+    fields: Optional[List[str]] = None,
+) -> List[Any]:
+    """Unified email search with OData filters."""
+
     select_fields = None if include_body else SELECT_FIELDS_NO_BODY
     messages = _fetch_emails(user_email, query_filter, folders, top, select_fields)
-    formatter = format_emails_list_structured if include_body else format_emails_list_structured_no_body
-    return _format_results(messages, structured, as_text, formatter, fields=fields)
+    formatter = (
+        format_emails_list_structured if include_body else format_emails_list_structured_no_body
+    )
+    return _format_results(
+        messages,
+        structured,
+        as_text,
+        formatter,
+        fields=fields,
+        clean_body=clean_body and include_body,
+    )
 
-def search_emails_by_search_query(user_email: str, search_query: str, folders: Optional[List[str]] = None, 
-                                 top: int = 10, as_text: bool = True, structured: bool = True, include_body: bool = True, fields: Optional[List[str]] = None) -> List[Any]:
-    """Unified email search with KQL queries"""
+def search_emails_by_search_query(
+    user_email: str,
+    search_query: str,
+    folders: Optional[List[str]] = None,
+    top: int = 10,
+    as_text: bool = True,
+    structured: bool = True,
+    include_body: bool = True,
+    clean_body: bool = True,
+    fields: Optional[List[str]] = None,
+) -> List[Any]:
+    """Unified email search with KQL queries."""
+
     select_fields = None if include_body else SELECT_FIELDS_NO_BODY
     messages = _fetch_emails_by_search(user_email, search_query, folders, top, select_fields)
-    formatter = format_emails_list_structured_search if include_body else format_emails_list_structured_search_no_body
-    return _format_results(messages, structured, as_text, formatter, fields=fields)
+    formatter = (
+        format_emails_list_structured_search
+        if include_body
+        else format_emails_list_structured_search_no_body
+    )
+    return _format_results(
+        messages,
+        structured,
+        as_text,
+        formatter,
+        fields=fields,
+        clean_body=clean_body and include_body,
+    )
 
 def get_email_by_id(message_id: str, user_email: str, as_text: bool = True, structured: bool = True) -> Optional[Any]:
     message = graph_client.users[user_email].messages[message_id].get().execute_query()


### PR DESCRIPTION
## Summary
- Avoid enumerating entire mailboxes when paginating message results
- Reuse a single Graph token for KQL folder searches and allow default folders via `OUTLOOK_DEFAULT_FOLDERS`
- Add `clean_body`/`deep_clean` options and refactor cleaning utilities for optional lightweight HTML processing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afef4bc6208333afcf1108309076ed